### PR TITLE
Fix Ubuntu version bug in CI

### DIFF
--- a/.github/workflows/test-coreferee.yml
+++ b/.github/workflows/test-coreferee.yml
@@ -8,24 +8,24 @@ jobs:
   test-coreferee:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
         python_version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         spacy_version: ['3.3.0']
         click_version: ['8.0.1']
         include:
-          - os: 'ubuntu-latest'
+          - os: 'ubuntu-20.04'
             python-version: '3.9'
             spacy_version: '3.4.2'
             click_version: '8.0.1'
-          - os: 'ubuntu-latest'
+          - os: 'ubuntu-20.04'
             python-version: '3.9'
             spacy_version: '3.2.0'
             click_version: '8.0.1'
-          - os: 'ubuntu-latest'
+          - os: 'ubuntu-20.04'
             python-version: '3.9'
             spacy_version: '3.1.0'
             click_version: '7.1.2'
-          - os: 'ubuntu-latest'
+          - os: 'ubuntu-20.04'
             python-version: '3.9'
             spacy_version: '3.0.0'
             click_version: '7.1.2'


### PR DESCRIPTION
The pre-existing version of the CI Github Actions definition used a Github Actions variable `ubuntu-latest` which appears to have recently been moved to point to Ubuntu version 22.01, for which there is no support for the older Python versions. This PR pegs the Ubuntu version to 20.01.